### PR TITLE
Remove local stub for quadria

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/rossus/codex-gen-quadria-ui
+
+go 1.23.8
+
+require github.com/rossus/quadria v0.0.0-20210424121910-a759079be286
+
+require (
+	github.com/buger/goterm v1.0.0 // indirect
+	github.com/kortschak/ct v0.0.0-20140325011614-7d86dffe6951 // indirect
+	golang.org/x/sys v0.0.0-20210331175145-43e1dd70ce54 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/buger/goterm v1.0.0 h1:ZB6uUlY8+sjJyFGzz2WpRqX2XYPeXVgtZAOJMwOsTWM=
+github.com/buger/goterm v1.0.0/go.mod h1:16STi3LquiscTIHA8SXUNKEa/Cnu4ZHBH8NsCaWgso0=
+github.com/kortschak/ct v0.0.0-20140325011614-7d86dffe6951 h1:I12D1A/+qvQfb7cENS32wTtXNF9dh7S8H847WGjnJ1U=
+github.com/kortschak/ct v0.0.0-20140325011614-7d86dffe6951/go.mod h1:5l1kPezpRemBE+Nj0tHiYk9JXHpgYwg0sOC5pvEScm8=
+github.com/rossus/quadria v0.0.0-20210424121910-a759079be286 h1:7t/bwZijYw1+X6b7cpIte36QYtD+QiIyt5I08uNKyXQ=
+github.com/rossus/quadria v0.0.0-20210424121910-a759079be286/go.mod h1:GTp8bvV3C3cSMnHJlh3DhJTRu0BQLLpYfwMP/SHw71k=
+golang.org/x/sys v0.0.0-20210331175145-43e1dd70ce54 h1:rF3Ohx8DRyl8h2zw9qojyLHLhrJpEMgyPOImREEryf0=
+golang.org/x/sys v0.0.0-20210331175145-43e1dd70ce54/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/main.go
+++ b/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+       "fmt"
+       "net/http"
+
+       "github.com/rossus/quadria/board"
+       "github.com/rossus/quadria/gameplay"
+       "github.com/rossus/quadria/players"
+)
+
+func boardHTML() string {
+       b := board.GetBoard()
+       html := "<table style='border-collapse:collapse'>"
+       for _, row := range b.Tiles {
+               html += "<tr>"
+               for _, t := range row {
+                       color := t.Player.Color
+                       if color == "" {
+                               color = "white"
+                       }
+                       html += fmt.Sprintf("<td style='border:1px solid #999;width:30px;height:30px;text-align:center;background:%s'>%d</td>", color, t.Value)
+               }
+               html += "</tr>"
+       }
+       html += "</table>"
+       return html
+}
+
+func main() {
+       players.InitPlayer("Blue", "blue")
+       players.InitPlayer("Red", "red")
+       board.InitNewBoard(5)
+       gameplay.StartNewGame()
+
+       http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+               fmt.Fprintf(w, "<html><body><h1>Quadria UI</h1>%s</body></html>", boardHTML())
+       })
+       http.ListenAndServe(":8080", nil)
+}


### PR DESCRIPTION
## Summary
- remove local quadria stub and rely on upstream module
- render Quadria board in minimal web UI

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_684f596e2dd48324be7ab516f6b1af7e