### PR TITLE
Add menu to select board size

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/rossus/codex-gen-quadria-ui
+
+go 1.23.8
+
+require github.com/rossus/quadria v0.0.0-20210424121910-a759079be286

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,5 @@
+github.com/buger/goterm v1.0.0/go.mod h1:16STi3LquiscTIHA8SXUNKEa/Cnu4ZHBH8NsCaWgso0=
+github.com/kortschak/ct v0.0.0-20140325011614-7d86dffe6951/go.mod h1:5l1kPezpRemBE+Nj0tHiYk9JXHpgYwg0sOC5pvEScm8=
+github.com/rossus/quadria v0.0.0-20210424121910-a759079be286 h1:7t/bwZijYw1+X6b7cpIte36QYtD+QiIyt5I08uNKyXQ=
+github.com/rossus/quadria v0.0.0-20210424121910-a759079be286/go.mod h1:GTp8bvV3C3cSMnHJlh3DhJTRu0BQLLpYfwMP/SHw71k=
+golang.org/x/sys v0.0.0-20210331175145-43e1dd70ce54/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/main.go
+++ b/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/rossus/quadria/board"
+	"github.com/rossus/quadria/gameplay"
+	"github.com/rossus/quadria/players"
+)
+
+func main() {
+	// Register players once when server starts.
+	players.InitPlayer("Blue", "blue")
+	players.InitPlayer("Red", "red")
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `<html><body><h1>Quadria UI</h1>`+
+			`<form action="/start" method="POST">`+
+			`Board size: <input type="number" name="size" value="3" min="2"/>`+
+			`<input type="submit" value="Start"/>`+
+			`</form></body></html>`)
+	})
+
+	http.HandleFunc("/start", func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "invalid form", http.StatusBadRequest)
+			return
+		}
+		size := 3
+		if val := r.FormValue("size"); val != "" {
+			if i, err := strconv.Atoi(val); err == nil && i > 0 {
+				size = i
+			}
+		}
+		board.InitNewBoard(size)
+		gameplay.StartNewGame()
+		http.Redirect(w, r, "/game", http.StatusSeeOther)
+	})
+
+	http.HandleFunc("/game", func(w http.ResponseWriter, r *http.Request) {
+		b := board.GetBoard()
+		fmt.Fprint(w, "<html><body><h1>Quadria UI</h1><table>")
+		for _, row := range b.Tiles {
+			fmt.Fprint(w, "<tr>")
+			for _, tile := range row {
+				fmt.Fprintf(w,
+					"<td style='width:30px;height:30px;text-align:center;background:%s'>%d</td>",
+					tile.Player.Color, tile.Value)
+			}
+			fmt.Fprint(w, "</tr>")
+		}
+		fmt.Fprint(w, "</table></body></html>")
+	})
+
+	http.ListenAndServe(":8080", nil)
+}


### PR DESCRIPTION
## Summary
- add an HTML form so the user can set board size before game start
- start a new game with the chosen board size and render it at `/game`

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_684f596e2dd48324be7ab516f6b1af7e