### PR TITLE
Refactor backend with structured router

### DIFF
--- a/constants/routes.go
+++ b/constants/routes.go
@@ -1,0 +1,8 @@
+package constants
+
+const (
+	RouteIndex = "/"
+	RouteStart = "/start"
+	RouteGame  = "/game"
+	ServerPort = ":8080"
+)

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/rossus/codex-gen-quadria-ui
 
 go 1.23.8
 
-require github.com/rossus/quadria v0.0.0-20210424121910-a759079be286
+require (
+	github.com/julienschmidt/httprouter v1.3.0
+	github.com/rossus/quadria v0.0.0-20210424121910-a759079be286
+)

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/buger/goterm v1.0.0/go.mod h1:16STi3LquiscTIHA8SXUNKEa/Cnu4ZHBH8NsCaWgso0=
+github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
+github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kortschak/ct v0.0.0-20140325011614-7d86dffe6951/go.mod h1:5l1kPezpRemBE+Nj0tHiYk9JXHpgYwg0sOC5pvEScm8=
 github.com/rossus/quadria v0.0.0-20210424121910-a759079be286 h1:7t/bwZijYw1+X6b7cpIte36QYtD+QiIyt5I08uNKyXQ=
 github.com/rossus/quadria v0.0.0-20210424121910-a759079be286/go.mod h1:GTp8bvV3C3cSMnHJlh3DhJTRu0BQLLpYfwMP/SHw71k=

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -1,0 +1,51 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/julienschmidt/httprouter"
+
+	"github.com/rossus/codex-gen-quadria-ui/constants"
+	"github.com/rossus/codex-gen-quadria-ui/types"
+	"github.com/rossus/quadria/board"
+	"github.com/rossus/quadria/gameplay"
+)
+
+// Index returns a handler for the index page.
+func Index(s *types.Server) httprouter.Handle {
+	return func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		if err := s.IndexTmpl.Execute(w, nil); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}
+}
+
+// Start handles starting a new game and redirects to the game page.
+func Start(s *types.Server) httprouter.Handle {
+	return func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "invalid form", http.StatusBadRequest)
+			return
+		}
+		size := 3
+		if val := r.FormValue("size"); val != "" {
+			if i, err := strconv.Atoi(val); err == nil && i > 0 {
+				size = i
+			}
+		}
+		board.InitNewBoard(size)
+		gameplay.StartNewGame()
+		http.Redirect(w, r, constants.RouteGame, http.StatusSeeOther)
+	}
+}
+
+// Game renders the current game board.
+func Game(s *types.Server) httprouter.Handle {
+	return func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		b := board.GetBoard()
+		if err := s.GameTmpl.Execute(w, b); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,51 +1,22 @@
 package main
 
 import (
-	"html/template"
+	"log"
 	"net/http"
-	"strconv"
 
-	"github.com/rossus/quadria/board"
-	"github.com/rossus/quadria/gameplay"
+	"github.com/rossus/codex-gen-quadria-ui/constants"
+	"github.com/rossus/codex-gen-quadria-ui/router"
+	"github.com/rossus/codex-gen-quadria-ui/types"
 	"github.com/rossus/quadria/players"
 )
 
 func main() {
-	indexTmpl := template.Must(template.ParseFiles("frontend/index.html"))
-	gameTmpl := template.Must(template.ParseFiles("frontend/game.html"))
-
 	// Register players once when server starts.
 	players.InitPlayer("Blue", "blue")
 	players.InitPlayer("Red", "red")
 
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		if err := indexTmpl.Execute(w, nil); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-	})
+	srv := types.NewServer()
+	r := router.NewRouter(srv)
 
-	http.HandleFunc("/start", func(w http.ResponseWriter, r *http.Request) {
-		if err := r.ParseForm(); err != nil {
-			http.Error(w, "invalid form", http.StatusBadRequest)
-			return
-		}
-		size := 3
-		if val := r.FormValue("size"); val != "" {
-			if i, err := strconv.Atoi(val); err == nil && i > 0 {
-				size = i
-			}
-		}
-		board.InitNewBoard(size)
-		gameplay.StartNewGame()
-		http.Redirect(w, r, "/game", http.StatusSeeOther)
-	})
-
-	http.HandleFunc("/game", func(w http.ResponseWriter, r *http.Request) {
-		b := board.GetBoard()
-		if err := gameTmpl.Execute(w, b); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-	})
-
-	http.ListenAndServe(":8080", nil)
+	log.Fatal(http.ListenAndServe(constants.ServerPort, r))
 }

--- a/router/router.go
+++ b/router/router.go
@@ -1,0 +1,18 @@
+package router
+
+import (
+	"github.com/julienschmidt/httprouter"
+
+	"github.com/rossus/codex-gen-quadria-ui/constants"
+	"github.com/rossus/codex-gen-quadria-ui/handlers"
+	"github.com/rossus/codex-gen-quadria-ui/types"
+)
+
+// NewRouter returns a configured httprouter.Router.
+func NewRouter(s *types.Server) *httprouter.Router {
+	r := httprouter.New()
+	r.GET(constants.RouteIndex, handlers.Index(s))
+	r.POST(constants.RouteStart, handlers.Start(s))
+	r.GET(constants.RouteGame, handlers.Game(s))
+	return r
+}

--- a/types/server.go
+++ b/types/server.go
@@ -1,0 +1,17 @@
+package types
+
+import "html/template"
+
+// Server stores pre-parsed templates used by handlers.
+type Server struct {
+	IndexTmpl *template.Template
+	GameTmpl  *template.Template
+}
+
+// NewServer loads templates and returns a Server instance.
+func NewServer() *Server {
+	return &Server{
+		IndexTmpl: template.Must(template.ParseFiles("frontend/index.html")),
+		GameTmpl:  template.Must(template.ParseFiles("frontend/game.html")),
+	}
+}


### PR DESCRIPTION
## Summary
- restructure backend into packages
- add constants for all routes and server port
- create typed server for templating
- implement handlers using httprouter
- wire up new router in main

## Testing
- `go mod tidy`
- `go build -v ./...`


------
https://chatgpt.com/codex/tasks/task_e_68506d3f97ac8324bf40bddc1178fbf6