### PR TITLE
Refactor router to accept prebuilt handler

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,25 @@
 <body>
 <h1>Quadria UI</h1>
 <form action="/start" method="POST">
-Board size: <input type="number" name="size" value="3" min="2"/>
+Board size: <input type="number" name="size" value="3" min="2"/><br/>
+<h3>Player 1</h3>
+Name: <input type="text" name="name1" value="Player One"/><br/>
+Color:
+<select name="color1">
+  <option value="blue" selected>Blue</option>
+  <option value="red">Red</option>
+  <option value="green">Green</option>
+  <option value="yellow">Yellow</option>
+</select><br/>
+<h3>Player 2</h3>
+Name: <input type="text" name="name2" value="Player Two"/><br/>
+Color:
+<select name="color2">
+  <option value="red" selected>Red</option>
+  <option value="blue">Blue</option>
+  <option value="green">Green</option>
+  <option value="yellow">Yellow</option>
+</select><br/>
 <input type="submit" value="Start"/>
 </form>
 </body>

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.23.8
 
 require (
 	github.com/julienschmidt/httprouter v1.3.0
-	github.com/rossus/quadria v0.0.0-20210424121910-a759079be286
+	github.com/rossus/quadria v0.0.0-20250701003649-5efa6b298467
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,6 @@ github.com/buger/goterm v1.0.0/go.mod h1:16STi3LquiscTIHA8SXUNKEa/Cnu4ZHBH8NsCaW
 github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kortschak/ct v0.0.0-20140325011614-7d86dffe6951/go.mod h1:5l1kPezpRemBE+Nj0tHiYk9JXHpgYwg0sOC5pvEScm8=
-github.com/rossus/quadria v0.0.0-20210424121910-a759079be286 h1:7t/bwZijYw1+X6b7cpIte36QYtD+QiIyt5I08uNKyXQ=
-github.com/rossus/quadria v0.0.0-20210424121910-a759079be286/go.mod h1:GTp8bvV3C3cSMnHJlh3DhJTRu0BQLLpYfwMP/SHw71k=
+github.com/rossus/quadria v0.0.0-20250701003649-5efa6b298467 h1:5zPHJbb5fBiBRzd0Ioje229NJ4L1Jg/7a7SX6T1slTE=
+github.com/rossus/quadria v0.0.0-20250701003649-5efa6b298467/go.mod h1:GTp8bvV3C3cSMnHJlh3DhJTRu0BQLLpYfwMP/SHw71k=
 golang.org/x/sys v0.0.0-20210331175145-43e1dd70ce54/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -10,42 +10,80 @@ import (
 	"github.com/rossus/codex-gen-quadria-ui/types"
 	"github.com/rossus/quadria/board"
 	"github.com/rossus/quadria/gameplay"
+	"github.com/rossus/quadria/players"
+	"github.com/rossus/quadria/session"
 )
 
-// Index returns a handler for the index page.
-func Index(s *types.Server) httprouter.Handle {
-	return func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-		if err := s.IndexTmpl.Execute(w, nil); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
+// Handler wraps the application server so route handlers can be defined as
+// methods without repeatedly passing the server around.
+type Handler struct {
+	Server *types.Server
+}
+
+// New returns a Handler bound to the provided Server.
+func New(s *types.Server) *Handler {
+	return &Handler{Server: s}
+}
+
+// Index renders the index page.
+func (h *Handler) Index(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	if err := h.Server.IndexTmpl.Execute(w, nil); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }
 
 // Start handles starting a new game and redirects to the game page.
-func Start(s *types.Server) httprouter.Handle {
-	return func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-		if err := r.ParseForm(); err != nil {
-			http.Error(w, "invalid form", http.StatusBadRequest)
-			return
-		}
-		size := 3
-		if val := r.FormValue("size"); val != "" {
-			if i, err := strconv.Atoi(val); err == nil && i > 0 {
-				size = i
-			}
-		}
-		board.InitNewBoard(size)
-		gameplay.StartNewGame()
-		http.Redirect(w, r, constants.RouteGame, http.StatusSeeOther)
+func (h *Handler) Start(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "invalid form", http.StatusBadRequest)
+		return
 	}
+	size := 3
+	if val := r.FormValue("size"); val != "" {
+		if i, err := strconv.Atoi(val); err == nil && i > 0 {
+			size = i
+		}
+	}
+	name1 := r.FormValue("name1")
+	if name1 == "" {
+		name1 = "Player One"
+	}
+	name2 := r.FormValue("name2")
+	if name2 == "" {
+		name2 = "Player Two"
+	}
+	color1 := r.FormValue("color1")
+	if color1 == "" {
+		color1 = "blue"
+	}
+	color2 := r.FormValue("color2")
+	if color2 == "" {
+		color2 = "red"
+	}
+
+	if name1 == name2 || color1 == color2 {
+		http.Error(w, "players must have distinct names and colors", http.StatusBadRequest)
+		return
+	}
+
+	pls := players.InitPlayers()
+	pls.AddPlayer(name1, color1)
+	pls.AddPlayer(name2, color2)
+
+	b := board.InitNewBoard(size, pls)
+	g := gameplay.InitializeNewGame(pls)
+	h.Server.Session = session.InitializeNewSession(pls, b, g)
+	http.Redirect(w, r, constants.RouteGame, http.StatusSeeOther)
 }
 
 // Game renders the current game board.
-func Game(s *types.Server) httprouter.Handle {
-	return func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-		b := board.GetBoard()
-		if err := s.GameTmpl.Execute(w, b); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
+func (h *Handler) Game(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	if h.Server.Session == nil {
+		http.Error(w, "no active game", http.StatusBadRequest)
+		return
+	}
+	b := h.Server.Session.Board.GetBoard()
+	if err := h.Server.GameTmpl.Execute(w, b); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -5,18 +5,15 @@ import (
 	"net/http"
 
 	"github.com/rossus/codex-gen-quadria-ui/constants"
+	"github.com/rossus/codex-gen-quadria-ui/handlers"
 	"github.com/rossus/codex-gen-quadria-ui/router"
 	"github.com/rossus/codex-gen-quadria-ui/types"
-	"github.com/rossus/quadria/players"
 )
 
 func main() {
-	// Register players once when server starts.
-	players.InitPlayer("Blue", "blue")
-	players.InitPlayer("Red", "red")
-
 	srv := types.NewServer()
-	r := router.NewRouter(srv)
+	h := handlers.New(srv)
+	r := router.NewRouter(h)
 
 	log.Fatal(http.ListenAndServe(constants.ServerPort, r))
 }

--- a/router/router.go
+++ b/router/router.go
@@ -5,14 +5,14 @@ import (
 
 	"github.com/rossus/codex-gen-quadria-ui/constants"
 	"github.com/rossus/codex-gen-quadria-ui/handlers"
-	"github.com/rossus/codex-gen-quadria-ui/types"
 )
 
-// NewRouter returns a configured httprouter.Router.
-func NewRouter(s *types.Server) *httprouter.Router {
+// NewRouter returns a configured httprouter.Router using the provided handler.
+func NewRouter(h *handlers.Handler) *httprouter.Router {
 	r := httprouter.New()
-	r.GET(constants.RouteIndex, handlers.Index(s))
-	r.POST(constants.RouteStart, handlers.Start(s))
-	r.GET(constants.RouteGame, handlers.Game(s))
+
+	r.GET(constants.RouteIndex, h.Index)
+	r.POST(constants.RouteStart, h.Start)
+	r.GET(constants.RouteGame, h.Game)
 	return r
 }

--- a/types/server.go
+++ b/types/server.go
@@ -1,11 +1,16 @@
 package types
 
-import "html/template"
+import (
+	"html/template"
+
+	"github.com/rossus/quadria/session"
+)
 
 // Server stores pre-parsed templates used by handlers.
 type Server struct {
 	IndexTmpl *template.Template
 	GameTmpl  *template.Template
+	Session   *session.Session
 }
 
 // NewServer loads templates and returns a Server instance.


### PR DESCRIPTION
## Summary
- inject a preconstructed `handlers.Handler` into `router.NewRouter`
- construct the handler in `main.go` before configuring routes
- keep player setup form with name/color validation for new games

## Testing
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68507377ef48832499cfc453e68fe5d6