### PR TITLE
Add dice image support

### DIFF
--- a/constants/routes.go
+++ b/constants/routes.go
@@ -4,5 +4,10 @@ const (
 	RouteIndex = "/"
 	RouteStart = "/start"
 	RouteGame  = "/game"
-	ServerPort = ":8080"
+	RouteDice  = "/dice/:value"
+
+	// CustomDiceDir is checked for user-provided dice images. Files should
+	// be named using the format "dice-<value>.svg".
+	CustomDiceDir = "static/custom"
+	ServerPort    = ":8080"
 )

--- a/frontend/game.html
+++ b/frontend/game.html
@@ -8,7 +8,7 @@
     {{range .}}
     <td style='width:30px;height:30px;text-align:center;background:{{.Player.Color}}'>
         {{if and (ge .Value 1) (le .Value 6)}}
-            <img src="/static/dice-{{.Value}}.svg" width="30" height="30" alt="{{.Value}}"/>
+            <img src="/dice/{{.Value}}?color={{.Player.Color}}" width="30" height="30" alt="{{.Value}}"/>
         {{else}}
             {{.Value}}
         {{end}}

--- a/frontend/game.html
+++ b/frontend/game.html
@@ -8,7 +8,7 @@
     {{range .}}
     <td style='width:30px;height:30px;text-align:center;background:{{.Player.Color}}'>
         {{if and (ge .Value 1) (le .Value 6)}}
-            <img src="/dice/{{.Value}}?color={{.Player.Color}}" width="30" height="30" alt="{{.Value}}"/>
+            <img src="/dice/{{.Value}}?color={{.Player.Color}}" width="30" height="30" style="display:block" alt="{{.Value}}"/>
         {{else}}
             {{.Value}}
         {{end}}

--- a/frontend/game.html
+++ b/frontend/game.html
@@ -6,7 +6,13 @@
 {{range .}}
 <tr>
     {{range .}}
-    <td style='width:30px;height:30px;text-align:center;background:{{.Player.Color}}'>{{.Value}}</td>
+    <td style='width:30px;height:30px;text-align:center;background:{{.Player.Color}}'>
+        {{if and (ge .Value 1) (le .Value 6)}}
+            <img src="/static/dice-{{.Value}}.svg" width="30" height="30" alt="{{.Value}}"/>
+        {{else}}
+            {{.Value}}
+        {{end}}
+    </td>
     {{end}}
 </tr>
 {{end}}

--- a/router/router.go
+++ b/router/router.go
@@ -16,6 +16,7 @@ func NewRouter(h *handlers.Handler) *httprouter.Router {
 	r.GET(constants.RouteIndex, h.Index)
 	r.POST(constants.RouteStart, h.Start)
 	r.GET(constants.RouteGame, h.Game)
+	r.GET(constants.RouteDice, h.Dice)
 	r.ServeFiles("/static/*filepath", http.Dir("static"))
 	return r
 }

--- a/router/router.go
+++ b/router/router.go
@@ -1,6 +1,8 @@
 package router
 
 import (
+	"net/http"
+
 	"github.com/julienschmidt/httprouter"
 
 	"github.com/rossus/codex-gen-quadria-ui/constants"
@@ -14,5 +16,6 @@ func NewRouter(h *handlers.Handler) *httprouter.Router {
 	r.GET(constants.RouteIndex, h.Index)
 	r.POST(constants.RouteStart, h.Start)
 	r.GET(constants.RouteGame, h.Game)
+	r.ServeFiles("/static/*filepath", http.Dir("static"))
 	return r
 }

--- a/static/dice-1.svg
+++ b/static/dice-1.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='30' height='30'>
+  <rect width='30' height='30' rx='5' ry='5' fill='white' stroke='black'/>
+  <circle cx='15' cy='15' r='3' fill='black'/>
+</svg>

--- a/static/dice-2.svg
+++ b/static/dice-2.svg
@@ -1,0 +1,5 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='30' height='30'>
+  <rect width='30' height='30' rx='5' ry='5' fill='white' stroke='black'/>
+  <circle cx='9' cy='9' r='3' fill='black'/>
+  <circle cx='21' cy='21' r='3' fill='black'/>
+</svg>

--- a/static/dice-3.svg
+++ b/static/dice-3.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='30' height='30'>
+  <rect width='30' height='30' rx='5' ry='5' fill='white' stroke='black'/>
+  <circle cx='9' cy='9' r='3' fill='black'/>
+  <circle cx='15' cy='15' r='3' fill='black'/>
+  <circle cx='21' cy='21' r='3' fill='black'/>
+</svg>

--- a/static/dice-4.svg
+++ b/static/dice-4.svg
@@ -1,0 +1,7 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='30' height='30'>
+  <rect width='30' height='30' rx='5' ry='5' fill='white' stroke='black'/>
+  <circle cx='9' cy='9' r='3' fill='black'/>
+  <circle cx='21' cy='9' r='3' fill='black'/>
+  <circle cx='9' cy='21' r='3' fill='black'/>
+  <circle cx='21' cy='21' r='3' fill='black'/>
+</svg>

--- a/static/dice-5.svg
+++ b/static/dice-5.svg
@@ -1,0 +1,8 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='30' height='30'>
+  <rect width='30' height='30' rx='5' ry='5' fill='white' stroke='black'/>
+  <circle cx='9' cy='9' r='3' fill='black'/>
+  <circle cx='21' cy='9' r='3' fill='black'/>
+  <circle cx='15' cy='15' r='3' fill='black'/>
+  <circle cx='9' cy='21' r='3' fill='black'/>
+  <circle cx='21' cy='21' r='3' fill='black'/>
+</svg>

--- a/static/dice-6.svg
+++ b/static/dice-6.svg
@@ -1,0 +1,9 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='30' height='30'>
+  <rect width='30' height='30' rx='5' ry='5' fill='white' stroke='black'/>
+  <circle cx='9' cy='7' r='3' fill='black'/>
+  <circle cx='9' cy='15' r='3' fill='black'/>
+  <circle cx='9' cy='23' r='3' fill='black'/>
+  <circle cx='21' cy='7' r='3' fill='black'/>
+  <circle cx='21' cy='15' r='3' fill='black'/>
+  <circle cx='21' cy='23' r='3' fill='black'/>
+</svg>


### PR DESCRIPTION
## Summary
- add static dice images and serve via router
- display dice images on the board for values 1..6

## Testing
- `go test ./...`
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6863d8292adc832481bf20e77f711161