### PR TITLE
Add tile click move support

### DIFF
--- a/constants/routes.go
+++ b/constants/routes.go
@@ -5,6 +5,7 @@ const (
 	RouteStart = "/start"
 	RouteGame  = "/game"
 	RouteDice  = "/dice/:value"
+	RouteMove  = "/move/:x/:y"
 
 	// CustomDiceDir is checked for user-provided dice images. Files should
 	// be named using the format "dice-<value>.svg".

--- a/frontend/game.html
+++ b/frontend/game.html
@@ -3,15 +3,17 @@
 <body>
 <h1>Quadria UI</h1>
 <table>
-{{range .}}
+{{range $y, $row := .}}
 <tr>
-    {{range .}}
-    <td style='width:30px;height:30px;text-align:center;background:{{.Player.Color}}'>
-        {{if and (ge .Value 1) (le .Value 6)}}
-            <img src="/dice/{{.Value}}?color={{.Player.Color}}" width="30" height="30" style="display:block" alt="{{.Value}}"/>
+    {{range $x, $tile := $row}}
+    <td style='width:30px;height:30px;text-align:center;background:{{$tile.Player.Color}}'>
+        <a href="/move/{{$x}}/{{$y}}" style="display:block;width:30px;height:30px;">
+        {{if and (ge $tile.Value 1) (le $tile.Value 6)}}
+            <img src="/dice/{{$tile.Value}}?color={{$tile.Player.Color}}" width="30" height="30" style="display:block" alt="{{$tile.Value}}"/>
         {{else}}
-            {{.Value}}
+            {{$tile.Value}}
         {{end}}
+        </a>
     </td>
     {{end}}
 </tr>

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -91,6 +91,28 @@ func (h *Handler) Game(w http.ResponseWriter, r *http.Request, _ httprouter.Para
 	}
 }
 
+// Move executes a player's turn on the selected tile then redirects to the game board.
+func (h *Handler) Move(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	if h.Server.Session == nil {
+		http.Error(w, "no active game", http.StatusBadRequest)
+		return
+	}
+
+	x, err := strconv.Atoi(ps.ByName("x"))
+	if err != nil {
+		http.Error(w, "invalid coordinates", http.StatusBadRequest)
+		return
+	}
+	y, err := strconv.Atoi(ps.ByName("y"))
+	if err != nil {
+		http.Error(w, "invalid coordinates", http.StatusBadRequest)
+		return
+	}
+
+	h.Server.Session.Go(x, y)
+	http.Redirect(w, r, constants.RouteGame, http.StatusSeeOther)
+}
+
 // Dice serves a dice image for the provided value. If a custom image exists in
 // constants.CustomDiceDir it is served. Otherwise an SVG is generated with the
 // dice background colored via the "color" query parameter.

--- a/router/router.go
+++ b/router/router.go
@@ -16,6 +16,7 @@ func NewRouter(h *handlers.Handler) *httprouter.Router {
 	r.GET(constants.RouteIndex, h.Index)
 	r.POST(constants.RouteStart, h.Start)
 	r.GET(constants.RouteGame, h.Game)
+	r.GET(constants.RouteMove, h.Move)
 	r.GET(constants.RouteDice, h.Dice)
 	r.ServeFiles("/static/*filepath", http.Dir("static"))
 	return r


### PR DESCRIPTION
## Summary
- allow clicking tiles to make moves
- add route `/move/:x/:y`
- update game template to link each tile

## Testing
- `go vet ./...`
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6865b7e953b083248150e1120f45f7ff