### PR TITLE
Enhance game screen with turn info

### DIFF
--- a/frontend/game.html
+++ b/frontend/game.html
@@ -2,8 +2,14 @@
 <html>
 <body>
 <h1>Quadria UI</h1>
+<h2>Turn {{.Turn}}</h2>
+<ul>
+{{range $p := .Players}}
+    <li style='color:{{$p.Color}}'>{{if eq $p.Name $.Active.Name}}<b>{{$p.Name}}</b>{{else}}{{$p.Name}}{{end}}</li>
+{{end}}
+</ul>
 <table>
-{{range $y, $row := .}}
+{{range $y, $row := .Tiles}}
 <tr>
     {{range $x, $tile := $row}}
     <td style='width:30px;height:30px;text-align:center;background:{{$tile.Player.Color}}'>

--- a/types/gameview.go
+++ b/types/gameview.go
@@ -1,0 +1,11 @@
+package types
+
+import qtypes "github.com/rossus/quadria/common/types"
+
+// GamePageData holds information passed to the game template.
+type GamePageData struct {
+	Tiles   [][]qtypes.Tile
+	Turn    int
+	Players []qtypes.Player
+	Active  qtypes.Player
+}

--- a/types/server.go
+++ b/types/server.go
@@ -3,6 +3,7 @@ package types
 import (
 	"html/template"
 
+	qtypes "github.com/rossus/quadria/common/types"
 	"github.com/rossus/quadria/session"
 )
 
@@ -11,6 +12,7 @@ type Server struct {
 	IndexTmpl *template.Template
 	GameTmpl  *template.Template
 	Session   *session.Session
+	Players   []qtypes.Player
 }
 
 // NewServer loads templates and returns a Server instance.


### PR DESCRIPTION
## Summary
- keep a list of players and expose it via the server type
- add `GamePageData` struct for game template
- show turn number and players in game view
- highlight the active player

## Testing
- `go build ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6865bc9e3a248324888d58e692a5cc90