### PR TITLE
Implement end game message and disable moves

### DIFF
--- a/frontend/game.html
+++ b/frontend/game.html
@@ -2,6 +2,10 @@
 <html>
 <body>
 <h1>Quadria UI</h1>
+{{if .Winner}}
+<h2>{{.Winner.Name}} wins!</h2>
+<p><a href="/">Start a new game</a></p>
+{{end}}
 <h2>Turn {{.Turn}}</h2>
 <ul>
 {{range $p := .Players}}
@@ -13,13 +17,15 @@
 <tr>
     {{range $x, $tile := $row}}
     <td style='width:30px;height:30px;text-align:center;background:{{$tile.Player.Color}}'>
+        {{if not $.Winner}}
         <a href="/move/{{$x}}/{{$y}}" style="display:block;width:30px;height:30px;">
+        {{end}}
         {{if and (ge $tile.Value 1) (le $tile.Value 6)}}
             <img src="/dice/{{$tile.Value}}?color={{$tile.Player.Color}}" width="30" height="30" style="display:block" alt="{{$tile.Value}}"/>
         {{else}}
             {{$tile.Value}}
         {{end}}
-        </a>
+        {{if not $.Winner}}</a>{{end}}
     </td>
     {{end}}
 </tr>

--- a/types/gameview.go
+++ b/types/gameview.go
@@ -8,4 +8,5 @@ type GamePageData struct {
 	Turn    int
 	Players []qtypes.Player
 	Active  qtypes.Player
+	Winner  *qtypes.Player
 }

--- a/types/server.go
+++ b/types/server.go
@@ -13,6 +13,7 @@ type Server struct {
 	GameTmpl  *template.Template
 	Session   *session.Session
 	Players   []qtypes.Player
+	Winner    *qtypes.Player
 }
 
 // NewServer loads templates and returns a Server instance.


### PR DESCRIPTION
## Summary
- track winning player in the server
- reset winner when starting a game
- send winner to the game template
- block new moves after the game ends
- show end game banner and disable board clicks

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68667c4c03cc832485d028f43acbc2d8